### PR TITLE
Update to go version 1.26

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,1 +1,1 @@
-apt_src golang-1.25
+apt_src golang-1.26


### PR DESCRIPTION
**What this PR does / why we need it**:
Update to go version `1.26`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4504